### PR TITLE
bugfix(cl/ps-ui): reset state upon pressing ESC

### DIFF
--- a/client/input.lua
+++ b/client/input.lua
@@ -1,6 +1,11 @@
 local p = nil
 local Active = false
 
+local function resetInputState()
+    p = nil
+    Active = false
+end
+
 local function Input(InputData)
     p = promise.new()
     while Active do Wait(0) end
@@ -20,12 +25,13 @@ exports("Input", Input)
 RegisterNUICallback('input-callback', function(data, cb)
 	SetNuiFocus(false, false)
     p:resolve(data.input)
-    p = nil
-    Active = false
+    resetInputState()
     cb('ok')
 end)
 
 RegisterNUICallback('input-close', function(data, cb)
     SetNuiFocus(false, false)
+    p:resolve(nil)
+    resetInputState()
     cb('ok')
 end)


### PR DESCRIPTION
If user is to press ESC upon using the ps-ui Input form they are no longer able to access again.

🔗 [https://medal.tv/games/gta-v/clips/T4Lnzn7u-g-w2/d13379tZHVVU?invite=cr-MSxYcmIsMTU2OTQ5MjQwLA](https://medal.tv/games/gta-v/clips/T4Lnzn7u-g-w2/d13379tZHVVU?invite=cr-MSxYcmIsMTU2OTQ5MjQwLA)

I have made it where this issue is resolved and another input form can be opened by resetting the input states upon pressing ESC.