### PR TITLE
V2 thermite backward compatibility

### DIFF
--- a/client/thermite.lua
+++ b/client/thermite.lua
@@ -16,7 +16,7 @@ local correctBlocksBasedOnGrid = {
 local function thermite(cb, time, gridsize, wrong, correctBlocks)
     -- Default values if parameters are not provided
     if time == nil then time = 10 end
-    if gridsize == nil then gridsize = 6 end
+    if gridsize <= 5 or gridsize == nil then gridsize = 6 end 
     if wrong == nil then wrong = 3 end
 
     local correctBlockCount = correctBlocks or correctBlocksBasedOnGrid[gridsize]


### PR DESCRIPTION
As the old version worked perfectly, the V2 had a break when having less than 5 GridSize, so i added this to the source file instead of changing it in every script. 

As the original check was only checking for if its a nil value. and not if its equal or under 5.


![image](https://github.com/user-attachments/assets/fe6e1696-ac14-45e8-b4b6-b5813e57fa38)
